### PR TITLE
OIDS for every topic

### DIFF
--- a/scr/DM_Asset.ili
+++ b/scr/DM_Asset.ili
@@ -15,8 +15,6 @@ VERSION "2021-08-16"  =
   IMPORTS GeometryCHLV95_V1,Units;
   IMPORTS CatalogueObjects_V1,CatalogueObjectTrees_V1,LocalisationCH_V1;
 
-
-
 !!****************************************
 !! DOMAINES
 !!****************************************
@@ -80,23 +78,11 @@ VERSION "2021-08-16"  =
       MultiTextDescrAtt : BAG {0..*} OF StTextDescr;
     END StMultiText;
 
-
-!!****************************************
-!! TOPIC 
-!!****************************************
-  TOPIC Basic =
-    !! Definition einer UUID für alles Klassen im Modell
-    OID AS INTERLIS.UUIDOID;
-
-  END Basic;
-
-
 !!****************************************
 !! TOPIC 
 !!****************************************
   TOPIC Catalogues =
-  DEPENDS ON Basic;
-
+    OID AS INTERLIS.UUIDOID;
 !! Codelist für das Attribut Asset.Kind
     CLASS KindItem
     EXTENDS CatalogueObjectTrees_V1.Catalogues.Item =
@@ -152,8 +138,8 @@ VERSION "2021-08-16"  =
 !! TOPIC 
 !!****************************************
   TOPIC CoreGeolAsset =
-  DEPENDS ON Basic, Catalogues; 
-  
+    OID AS INTERLIS.UUIDOID;
+  DEPENDS ON Catalogues; 
 !!****************************************
 !! CLASSES
 !!****************************************


### PR DESCRIPTION
Gestern hat mir der Externe noch einige Inputs gegeben. Zudem fragte er mich, weshalb wir das TOPIC Base haben für nur die OIDs. Ich habs ihm dann erklärt, dass wir Probleme hatten mit der OID in jedem einzelnen TOPIC. Er wusste darauf gerade auch keine Lösung - bzw. hat den Fehler nicht erkannt den wir gemacht haben:
OID muss vor dem "Depends" stehen. Ich habs erst herausgefunden als ich nochmals in anderen Models nach ähnlichen Herangehensweisen suchte. Auf jeden Fall sollte es so funktionieren.