### PR TITLE
Multiple Single Geometries instead of single Multigeometry

### DIFF
--- a/scr/DM_Asset.ili
+++ b/scr/DM_Asset.ili
@@ -28,34 +28,6 @@ VERSION "2021-08-16"  =
 	!! Lokale Koordinaten der BBOX eines extrahierten Objektes auf einer Seite eines AssetMains
     ObjectCoord = COORD 0 .. 10000, 0 .. 10000;
 
-    !! BAG OF with INTERLIS 2.3 only possible with STRUCTURE
-    STRUCTURE PointStructure = 
-      Point: GeometryCHLV95_V1.Coord2;
-    END PointStructure;
-        
-    !!@ili2db.mapping=MultiPoint
-    STRUCTURE MultiPoint =
-      Points: BAG {1..*} OF PointStructure;
-    END MultiPoint;
-        
-    STRUCTURE LineStructure = 
-      Line: Line;
-    END LineStructure;
-        
-    !!@ili2db.mapping=MultiLine
-    STRUCTURE MultiLine =
-      Lines: BAG {1..*} OF LineStructure;
-    END MultiLine;
-        
-    STRUCTURE SurfaceStructure = 
-      Surface: Surface;
-    END SurfaceStructure;
-        
-    !!@ili2db.mapping=MultiSurface
-    STRUCTURE MultiSurface =
-      Surfaces: BAG {1..*} OF SurfaceStructure;
-    END MultiSurface;
-
     !!Strukur für die Modellierung von Adressen
     STRUCTURE Adress =
       Street : TEXT*20;
@@ -307,7 +279,6 @@ VERSION "2021-08-16"  =
     CLASS AssetBase (ABSTRACT) =
       TitlePublic : MANDATORY TEXT*80;
       DateCreation : MANDATORY FORMAT INTERLIS.XMLDate "1582-1-1" .. "2222-12-31";
-
     END AssetBase;
 
 
@@ -398,7 +369,7 @@ VERSION "2021-08-16"  =
         orginal
       );
 
-      !! Bemerkung zur Region of interest
+      !! Bemerkung zur Geometry
       Remark : TEXT*254;
 
     END GeometryOfInterest;
@@ -407,21 +378,21 @@ VERSION "2021-08-16"  =
     !! CLASS Punktgeometrien
     CLASS StudyLocation
     EXTENDS GeometryOfInterest =
-      Geometry : MultiPoint;
+      Geometry : GeometryCHLV95_V1.Coord2;
     END StudyLocation;
 
 
     !! CLASS Liniengeometrien
     CLASS StudySection
     EXTENDS GeometryOfInterest =
-      Geometry : MultiLine;
+      Geometry : Line;
     END StudySection;
 
 
     !! CLASS Polygongeometrien
     CLASS StudyArea
     EXTENDS GeometryOfInterest =
-      Geometry : MultiSurface;
+      Geometry : Surface;
     END StudyArea;
 
 
@@ -522,7 +493,6 @@ VERSION "2021-08-16"  =
       AssetBase -- {1..*} AssetBase;
       Publication -- {0..*} Publication;
     END AssetBase_Publication;
-
 
     !! Untersuchungsgebiet zu einem Asset
     ASSOCIATION AssetBase_GeometryOfInterest =

--- a/scr/DM_Asset.ili
+++ b/scr/DM_Asset.ili
@@ -478,7 +478,8 @@ VERSION "2021-08-16"  =
       AssetItemPart -- {0..*} AssetItem;
       !! Ein AssetPart kann keine weiteren Parts enthalten. Somit ist die Beziehung nur gültig, wenn der AssetMain nicht selbst ein AssetMain als Parent hat.
       MANDATORY CONSTRAINT
-        NOT (DEFINED (AssetItemMain->AssetItemMain));
+        NOT (AssetItemMain->IsMain)
+        AND NOT (AssetItemPart->IsMain);
     END AssetItemMain_AssetItemPart; 
 
     !! Ein Asset ist Teil eines AssetPackages. Ein AssetPackage beinhaltet 0..* Assets
@@ -497,7 +498,7 @@ VERSION "2021-08-16"  =
     !! Untersuchungsgebiet zu einem Asset
     ASSOCIATION AssetBase_GeometryOfInterest =
       AssetBase -- {1} AssetBase;
-      GeometryOfInterest -- {0..1} GeometryOfInterest;
+      GeometryOfInterest -- {0..*} GeometryOfInterest;
     END AssetBase_GeometryOfInterest;
 
     !! Autor


### PR DESCRIPTION
... und zwar weil wir dann die GeomQuality pro Geometrie machen können.

Doch dafür hab ich PR #29 geschlossen. Ich hab mich doch gegen die dortige Anpassung entschieden. Hier die Erleuterung dazu:

Struktur A:
```
    CLASS GeometryOfInterest (ABSTRACT)=
      !! Bemerkung zur Geometry
      Remark : TEXT*254;
    END GeometryOfInterest;

    CLASS StudyLocation
    EXTENDS GeometryOfInterest =
      Geometry : Point;
    END StudyLocation;

    CLASS StudySection
    EXTENDS GeometryOfInterest =
      Geometry : Line;
    END StudySection;
    
    CLASS StudyArea
    EXTENDS GeometryOfInterest =
      Geometry : Surface;
    END StudyArea;
```
Struktur B
```
    CLASS GeometryOfInterest (ABSTRACT)=
      !! Bemerkung zur Geometry
      Remark : TEXT*254;=
      StudyLocation : Point;
      StudySection : Line;
      StudyArea : Surface;
    END GeometryOfInterest;
```
Ich hab noch abgewogen. Sollen wir nun wirklich Struktur B verwenden oder doch bei der ursprünglichen Struktur A bleiben? Aufgrund der aktuellen Ausgangslage steht uns beides offen. Vorteil von Struktur A ist, dass es mutually exclusive ist (also eigentlich korrekter), Vorteil von Struktur B ist, dass es schlänker im Modell ist. Es hält sich meiner Meinung nach ziemlich die Waage. Den Grund, weshalb ich doch die ursprüngliche Struktur A nehmen würde: Wenn es ein kleines Modell mit nur drei Klassen wäre, fände ich B eine angemessene Lösung. Doch da es sich ohnehin schon um ein grösseres Modell handelt, denke ich, können wir die maximale Korrektheit uns leisten und Struktur A verwenden. 

Deshalb hab ich diesbezüglich nur folgendes geändert:
- Single Geometries anstatt multi Geometries
- 1-* Beziehung zu GeometryOfInterest (anstatt 1-0..1)

Betreffend dem CONSTRAINT zur Sicherstellung, ob nicht ein  `AssetItem` UND ein  `AssetPackage` dem Geometrieobjekt zugewiesen wird, hab ich auch noch etwas nachgeforscht und getestet. **Es ist kein CONSTRAINT notwendig**. Denn dies wird schon mit der Kardinalität in der Association sichergestellt. Auch wenn `AssetBase` mehrfach vererbt wird.

Stellt sich die Frage, ob du trotzdem einen `AssetType` im  `GeometryOfInterest ` verwenden möchtest.
 ```
      AssetType: MANDATORY (item, package);
 ```
Die GUI Implementation wär vermutlich einfacher. Aber ich find nicht so gut, wenn nur um die Voraussetzung für das GUI zu verbessern, ein Attribut ohne wirklichen Informationsgehalt eingefürt wird. Deshalb würde ich es eher weg lassen.
 