### PR TITLE
Import optimization

### DIFF
--- a/scr/GeolAssetsCatalogues_V1.ili
+++ b/scr/GeolAssetsCatalogues_V1.ili
@@ -13,7 +13,7 @@ VERSION "2021-12-08" =
 !!****************************************
 !! IMPORTS
 !!****************************************
-IMPORTS CatalogueObjects_V1,CatalogueObjectTrees_V1,LocalisationCH_V1;
+IMPORTS CatalogueObjectTrees_V1,LocalisationCH_V1;
 
 
 !!****************************************

--- a/scr/GeolAssets_V1.ili
+++ b/scr/GeolAssets_V1.ili
@@ -13,8 +13,7 @@ VERSION "2021-12-08"  =
 !!****************************************
 !! IMPORTS
 !!****************************************
-  IMPORTS GeometryCHLV95_V1,Units;
-  IMPORTS CatalogueObjects_V1,CatalogueObjectTrees_V1,LocalisationCH_V1;
+  IMPORTS GeometryCHLV95_V1;
   IMPORTS GeolAssetsCatalogues_V1;
 
 !!****************************************

--- a/scr/LG_GeolAssets_V1.ili
+++ b/scr/LG_GeolAssets_V1.ili
@@ -15,8 +15,6 @@ VERSION "2021-12-08" =
 !!****************************************
 !! IMPORTS
 !!****************************************
-  IMPORTS GeometryCHLV95_V1,Units;
-  IMPORTS CatalogueObjects_V1,CatalogueObjectTrees_V1,LocalisationCH_V1;
   IMPORTS GeolAssets_V1,LG_GeolAssetsCatalogues_V1;
 
 

--- a/scr/LG_GeolAssets_V1.ili
+++ b/scr/LG_GeolAssets_V1.ili
@@ -99,7 +99,7 @@ VERSION "2021-12-08" =
 	
     !! ----------
 	MANDATORY CONSTRAINT
-      isOCR <> #true OR DEFINED (OCRQuality);
+      IsOCR <> #true OR DEFINED (OCRQuality);
 	  
 	MANDATORY CONSTRAINT
       OCRQuality->Reference->Name->LocalisedText->Text=="low" OR DEFINED (DateOCRProcessing);
@@ -188,7 +188,7 @@ VERSION "2021-12-08" =
 
     !! ----------
     MANDATORY CONSTRAINT
-      isRestricted <> #true OR DEFINED (DateRestriction);
+      IsRestricted <> #true OR DEFINED (DateRestriction);
 
     !! ----------
     END LGAssetBase;


### PR DESCRIPTION
Was hälst du davon @oesterli ?

Hier eine kleine Erläuterung über die Imports:
Wir importiernen Model1 ins Model2 - dort können wir Objekte des Model1 verwenden so Model1.TopicOf1.ObjectOf1. Wenn wir ein Objekt in Model2 nun erweitern (also ExtendedObjectOf2 mit Model1.TopicOf1.ObjectOf1) und dann Model2 in Model3 importieren, dann können wir die Attribute von Model1.TopicOf1.ObjectOf1 in Model3 mit Model2.ExtendetTopicOf2.ExtendedObjectOf2 nutzen ohne Model1 zu Importieren. Allerdings nur die erweiterten Objekte von Model2. Wir können nicht auf Objekte von Model1 zugreiffen, nur weil wir Model2 importieren, welches Model1 importiert hat.

Nun macht  es meiner Meinung nach keinen Sinn, wenn man Topics und Klassen in Model2 nur mit Model1 extended, damit dann in Model3 ein Import weniger gemacht werden soll. Dennoch scheint es mir in diesem Fall mit dem Extend von Catalogues in LG_GeolAssetsCodelists sinnvoll. Es ist ja auch bisschen was erwartet wird, dass wir das Haupt-Topic in LG_GeolAsset mit GeolAsset extenden und somit dies auch beim Catalogue tun. Hoffe das ist gut für dich.

Übrigens noch zwei Sachen:
- Codelisten werden oft als XML abgespeichert. XTF sind meistens Nutzdaten. Der Inhalt ist derselbe. Deshalb funktioniert beides. Allerdings sieht man dann am File, wonach es sich handelt.
- Du hast einen Ordner scr - sollte der nicht src sein von "Source"? 